### PR TITLE
ci(codeql): sync codeql-action versions and group dependabot bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,12 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      # codeql-action sub-actions (init/analyze/upload-sarif) must be bumped
+      # together: analyze refuses to run against an init of a different version.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
   - package-ecosystem: cargo
     directory: /packages/ghaf-mem-manager
     schedule:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -73,12 +73,12 @@ jobs:
         # - name: Setup runtime (example)
         #   uses: actions/setup-example@v1
 
-        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           config-file: ./.github/codeql-config.yml
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Problem

Both #336 and #332 are Dependabot PRs bumping the CodeQL action, and both fail **all** the `Analyze` CodeQL jobs with:

```
##[error]Loaded a configuration file for version '4.37.3', but running version '4.37.0'
```

### Root cause

`codeql.yml` uses two sub-actions of the same package, which **must run at the identical version** — `analyze` reads a config file stamped by `init` and aborts on any version mismatch.

Dependabot treats `github/codeql-action/init` and `github/codeql-action/analyze` as **independent** dependencies and opens a **separate PR for each**:

- #336 bumped only `init` → v4.37.3 (left `analyze` at v4.37.0)
- #332 bumped only `analyze` → v4.37.3 (left `init` at v4.37.0)

Either way the two steps end up on different versions, so neither PR can pass on its own.

## Fix

1. **`codeql.yml`** — bump `init` **and** `analyze` to `v4.37.3` (`e4fba86`) together in a single change.
2. **`dependabot.yml`** — add a `codeql-action` group so all `github/codeql-action*` sub-actions are always bumped in one PR going forward, preventing this from recurring.

This supersedes #336 and #332, which can be closed once this merges.

## Notes

- `scorecards.yml`'s `upload-sarif` (v3.30.8) is left untouched — it runs in a separate workflow and does not need to match the codeql.yml init/analyze pairing. The new group will keep it in sync with future codeql-action bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)