### PR TITLE
feat(fortivpn): add FortiSSLVPN configuration application

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Python applications and utilities, all modernized with `pyproject.toml` + `uv`.
 High-performance system utilities written in Rust.
 
 - **`ghaf-kill-switch-app`** - GUI Application for kill switch
+- **`ghaf-fortivpn`** - Secure COSMIC certificate importer for Fortinet VPN profiles
+- **`ghaf-fortivpn-service`** - Hardened certificate-import backend for `net-vm`
 - **`ghaf-mem-manager`** - Memory management utilities
 - **`ghaf-nw-packet-forwarder`** - Network packet forwarding service
 
@@ -92,6 +94,8 @@ nix develop
 nix build .#ghaf-audio-control
 nix build .#ghaf-mem-manager
 nix build .#ghaf-kill-switch-app
+nix build .#ghaf-fortivpn
+nix build .#ghaf-fortivpn-service
 nix build .#ghaf-usb-applet
 nix build .#gps-websock
 nix build .#vsockproxy

--- a/flake.lock
+++ b/flake.lock
@@ -86,6 +86,23 @@
         "type": "github"
       }
     },
+    "ghaf-fortivpn": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1787695055,
+        "narHash": "sha256-3Sdsac5uKb0Q/RFRtJM3JYBxe1ZjVHCfeum7m5+O1/Y=",
+        "owner": "tiiuae",
+        "repo": "ghaf-fortivpn",
+        "rev": "98d4359773c9ae3635ede828abd0b9534d339be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tiiuae",
+        "repo": "ghaf-fortivpn",
+        "rev": "98d4359773c9ae3635ede828abd0b9534d339be8",
+        "type": "github"
+      }
+    },
     "git-hooks-nix": {
       "inputs": {
         "flake-compat": [
@@ -132,6 +149,7 @@
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "flake-root": "flake-root",
+        "ghaf-fortivpn": "ghaf-fortivpn",
         "git-hooks-nix": "git-hooks-nix",
         "nixpkgs": "nixpkgs",
         "treefmt-nix": "treefmt-nix"

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,11 @@
       url = "github:ipetkov/crane";
     };
 
+    ghaf-fortivpn = {
+      url = "github:tiiuae/ghaf-fortivpn/98d4359773c9ae3635ede828abd0b9534d339be8";
+      flake = false;
+    };
+
     devshell = {
       url = "github:numtide/devshell";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/packages/flake-module.nix
+++ b/packages/flake-module.nix
@@ -12,7 +12,11 @@ let
   # recursion when the overlay is composed with other overlays via
   # `composeManyExtensions`).
   mkGhafpkgs =
-    { pkgs, crane }:
+    {
+      pkgs,
+      crane,
+      ghafFortivpnSrc,
+    }:
     let
       inherit (pkgs) callPackage python3Packages;
 
@@ -22,6 +26,7 @@ let
       rustPackages = import ./rust {
         inherit callPackage;
         inherit crane;
+        inherit ghafFortivpnSrc;
       };
       cppPackages = import ./cpp { inherit callPackage; };
 
@@ -38,6 +43,7 @@ in
       packages = mkGhafpkgs {
         inherit pkgs;
         inherit (inputs) crane;
+        ghafFortivpnSrc = inputs.ghaf-fortivpn;
       };
     };
 
@@ -48,5 +54,6 @@ in
     mkGhafpkgs {
       pkgs = prev;
       inherit (inputs) crane;
+      ghafFortivpnSrc = inputs.ghaf-fortivpn;
     };
 }

--- a/packages/rust/default.nix
+++ b/packages/rust/default.nix
@@ -1,7 +1,19 @@
 # SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
 # SPDX-License-Identifier: Apache-2.0
-{ callPackage, crane }:
 {
+  callPackage,
+  crane,
+  ghafFortivpnSrc,
+}:
+{
+  ghaf-fortivpn = callPackage ./ghaf-fortivpn {
+    inherit crane ghafFortivpnSrc;
+    component = "gui";
+  };
+  ghaf-fortivpn-service = callPackage ./ghaf-fortivpn {
+    inherit crane ghafFortivpnSrc;
+    component = "service";
+  };
   ghaf-kill-switch-app = callPackage ./ghaf-kill-switch-app { inherit crane; };
   ghaf-mem-manager = callPackage ./ghaf-mem-manager { inherit crane; };
   ghaf-nw-packet-forwarder = callPackage ./ghaf-nw-packet-forwarder { inherit crane; };

--- a/packages/rust/ghaf-fortivpn/default.nix
+++ b/packages/rust/ghaf-fortivpn/default.nix
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2026 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+{
+  component,
+  crane,
+  ghafFortivpnSrc,
+  lib,
+  pkgs,
+}:
+let
+  craneLib = crane.mkLib pkgs;
+  isGui = component == "gui";
+  packageName = if isGui then "ghaf-fortivpn" else "ghaf-fortivpn-service";
+  dlopenLibraries = with pkgs; [
+    libxkbcommon
+    vulkan-loader
+    wayland
+  ];
+  commonArgs = {
+    src = ghafFortivpnSrc + "/${component}";
+    strictDeps = true;
+    pname = packageName;
+    version = "0.1.0";
+    cargoExtraArgs = "-p ${packageName}";
+    CARGO_BUILD_INCREMENTAL = "false";
+    RUST_BACKTRACE = "1";
+    nativeBuildInputs = [ pkgs.pkg-config ] ++ lib.optional isGui pkgs.makeWrapper;
+    buildInputs = lib.optionals isGui dlopenLibraries ++ lib.optional (!isGui) pkgs.openssl;
+  };
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+  cargoTest = craneLib.cargoTest (commonArgs // { inherit cargoArtifacts; });
+  cargoClippy = craneLib.cargoClippy (
+    commonArgs
+    // {
+      inherit cargoArtifacts;
+      cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+    }
+  );
+in
+craneLib.buildPackage (
+  commonArgs
+  // {
+    inherit cargoArtifacts;
+
+    passthru.tests = {
+      inherit cargoClippy cargoTest;
+    };
+
+    postInstall = lib.optionalString isGui ''
+      wrapProgram "$out/bin/ghaf-fortivpn" \
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath dlopenLibraries}
+
+      install -Dm644 org.ghaf.FortiVpn.desktop \
+        "$out/share/applications/org.ghaf.FortiVpn.desktop"
+    '';
+
+    meta = {
+      description =
+        if isGui then
+          "Secure Fortinet VPN profile creator for Ghaf"
+        else
+          "Backend for secure Fortinet VPN profile creation in Ghaf";
+      homepage = "https://github.com/tiiuae/ghaf-fortivpn";
+      license = lib.licenses.asl20;
+      mainProgram = packageName;
+      platforms = lib.platforms.linux;
+    };
+  }
+)


### PR DESCRIPTION
<!--
    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
    SPDX-License-Identifier: CC-BY-SA-4.0
-->

## Description

is PR adds a FortiSSLVPN configuration application for Ghaf.It provides:

- A libcosmic interface in `gui-vm` for entering the VPN connection details.
- A backend in `net-vm` that validates the request and creates a native NetworkManager profile.
- Support for gateway, port, realm, credentials, trusted certificate fingerprints, and optional PKCS#12, PEM, or DER certificate material.
- Secure handling of VPN credentials and private keys without exposing secrets through command-line arguments.

Created profiles appear in COSMIC **Network & Wireless → VPN**, where users can connect, disconnect, and remove them using the native COSMIC interface.

### Motivation

NetworkManager and its FortiSSLVPN plugin already provide the VPN connection backend, and COSMIC can manage an existing VPN profile. However, the native COSMIC workflow does not provide an end-to-end way to create a complete FortiSSLVPN profile across Ghaf's VM boundary.

In particular, certificate files selected in `gui-vm` are not directly accessible to NetworkManager in `net-vm`. The native interface therefore cannot securely transfer, validate, and persist PKCS#12 or separate certificate and private-key material in the VM where the VPN connection runs.

This application fills that gap while continuing to use native NetworkManager profiles and the existing FortiSSLVPN plugin. It does not implement a separate VPN protocol or connection manager.

<!-- Provide a clear and concise description of what this PR does -->

## Related Issues

<!-- Link to related issues using keywords like "Fixes #123" or "Closes #456" -->
<!-- Remove this section if not applicable -->

Fixes #
Related to #

## Type of Change

<!-- Mark the relevant option with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Dependency update
- [x] Nix configuration change
- [ ] Other (please describe):

## Changes Made

<!-- List the key changes in bullet points. Be specific. -->

- Add a libcosmic Fortinet VPN configuration application that follows the active COSMIC light or dark theme.

- Add a privileged backend for validating profile fields, importing certificate material, and creating native NetworkManager FortiSSLVPN profiles.

- Support optional PKCS#12 (`.p12` and `.pfx`), PEM, DER, and PKCS#8 certificate and private-key formats.

- Validate certificate validity and ensure that the selected client certificate matches its private key.

- Store imported private keys as root-owned mode `0600` files inside mode `0700` profile directories.

- Submit VPN credentials directly through NetworkManager D-Bus without placing secrets in command-line arguments, environment variables, logs, or application state files.

- Add package documentation covering supported inputs, security properties, deployment requirements, and build commands.


## Testing Done

<!-- Describe the testing you performed -->

- [x] Built locally with `nix build .#<package-name>`
- [x] Ran `nix flake check` (all packages build successfully)
- [x] Ran `nix fmt -- --fail-on-change` (formatting check passed)
- [x] Ran `reuse lint` (license compliance verified)
- [x] Tested in Ghaf environment (if applicable)
- [x] Manual testing performed:
  - Created a FortiSSLVPN profile from the application in `gui-vm`.
  - Imported PKCS#12 client certificate material through the application.
  - Verified that the resulting profile appeared in COSMIC **Network & Wireless → VPN**.
  - Verified that certificate and private-key paths were persisted in the NetworkManager profile.
  - Connected, disconnected, and reconnected to a Fortinet VPN through the COSMIC Network & Wireless interface.

## Package Impact

<!-- Which packages are affected by this change? -->

Affected packages:
- `ghaf-fortivpn` — libcosmic configuration application
- `ghaf-fortivpn-service` — privileged NetworkManager profile backend


## Screenshots/Logs

<!-- If applicable, add screenshots or relevant log output -->
<!-- Remove this section if not applicable -->

<details>
<summary>Click to expand</summary>

<img width="760" height="847" alt="Screenshot_2026-08-06_16-09-33" src="https://github.com/user-attachments/assets/f9a2601e-dfff-43bd-a425-be74dee4d26d" />
<img width="1024" height="768" alt="Screenshot_2026-08-06_16-09-52" src="https://github.com/user-attachments/assets/7c94bde5-b94a-4437-8522-2437a2cdb5b7" />


</details>

## Checklist

<!-- Verify all items before submitting -->

- [x] Code follows project style guidelines (`nix fmt` passed)
- [x] SPDX license headers added to all new files
- [x] Documentation updated (README, inline comments, etc.)
- [x] No trailing whitespace in modified files
- [x] Commit messages follow [guidelines](../CONTRIBUTING.md#commit-message-guidelines)
- [x] No breaking changes (or clearly documented if unavoidable)
- [x] Security implications considered (no secrets, proper validation)
- [x] Nix best practices followed (no `rec`, explicit `lib.` usage)

## Additional Notes

<!-- Any additional context, concerns, or discussion points -->
<!-- Remove this section if not applicable -->

---

**For Reviewers:**

<!-- Optional: Add specific review instructions or areas of focus -->

1. Launch the Fortinet VPN application in `gui-vm`.
2. Enter a profile name, gateway, port, realm, username, and password. Optionally select a PKCS#12 bundle or separate certificate material.
3. Add the profile and verify that the application reports success and clears the form.
4. Open COSMIC Network & Wireless → VPN and verify that the new profile is present.
5. Connect, disconnect, and reconnect using the native COSMIC VPN controls.
6. For the security review, please check the D-Bus interface, certificate validation, input limits, secret handling, and permissions applied to imported private keys.