### PR TITLE
ghaf-mem-manager: Add Crosvm balloon support

### DIFF
--- a/packages/rust/ghaf-mem-manager/Cargo.lock
+++ b/packages/rust/ghaf-mem-manager/Cargo.lock
@@ -339,6 +339,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +424,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys",

--- a/packages/rust/ghaf-mem-manager/Cargo.toml
+++ b/packages/rust/ghaf-mem-manager/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = "1.0"
 clap = { version = "4.6", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio = { version = "1.53", features = ["rt", "net", "macros", "fs", "time", "io-util", "sync"] }
+tokio = { version = "1.53", features = ["rt", "net", "macros", "fs", "time", "io-util", "process", "sync"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 

--- a/packages/rust/ghaf-mem-manager/README.md
+++ b/packages/rust/ghaf-mem-manager/README.md
@@ -1,0 +1,34 @@
+<!--
+    SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+    SPDX-License-Identifier: CC-BY-SA-4.0
+-->
+
+# Ghaf Memory Manager
+
+`ghaf-mem-manager` monitors virtio-balloon statistics and keeps guest-visible
+memory pressure within a configured window. QEMU's QMP protocol is the default
+backend.
+
+```sh
+ghaf-mem-manager \
+  --socket /run/microvm/app-vm.sock \
+  --minimum 4294967296 \
+  --maximum 12884901888
+```
+
+Select the Crosvm backend explicitly and provide the Crosvm executable used by
+the VM:
+
+```sh
+ghaf-mem-manager \
+  --hypervisor crosvm \
+  --crosvm-binary /path/to/crosvm \
+  --socket /run/microvm/app-vm.sock \
+  --minimum 4294967296 \
+  --maximum 12884901888
+```
+
+`--maximum` is required for Crosvm. QEMU's balloon command specifies the memory
+left visible to the guest, while Crosvm's command specifies the memory reclaimed
+from the guest. The Crosvm backend translates between those semantics using the
+configured maximum.

--- a/packages/rust/ghaf-mem-manager/default.nix
+++ b/packages/rust/ghaf-mem-manager/default.nix
@@ -59,7 +59,7 @@ let
           A memory management service for the Ghaf framework that provides
           memory monitoring, allocation tracking, and resource management
           for virtualized environments. Features include memory usage monitoring,
-          QEMU integration, and resource optimization.
+          QEMU and Crosvm integration, and resource optimization.
         '';
         homepage = "https://ghaf.dev";
         license = lib.licenses.asl20;

--- a/packages/rust/ghaf-mem-manager/src/crosvm.rs
+++ b/packages/rust/ghaf-mem-manager/src/crosvm.rs
@@ -53,11 +53,30 @@ impl CrosvmEndpoint {
         command.args(arguments).kill_on_drop(true);
         let output = timeout(TIMEOUT, command.output())
             .await
-            .context("crosvm control command timed out")??;
+            .with_context(|| {
+                format!(
+                    "crosvm `{}` timed out after {TIMEOUT:?}",
+                    arguments.join(" ")
+                )
+            })?
+            .with_context(|| {
+                format!("failed to execute crosvm binary {}", self.binary.display())
+            })?;
         if !output.status.success() {
+            // Crosvm reports some control failures on stdout, including
+            // unexpected VM responses and failed balloon statistics requests.
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let detail = match (stderr.trim(), stdout.trim()) {
+                ("", "") => "<no output>".to_owned(),
+                ("", out) => out.to_owned(),
+                (err, "") => err.to_owned(),
+                (err, out) => format!("{err}; stdout: {out}"),
+            };
             bail!(
-                "crosvm control command failed: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
+                "crosvm `{}` exited with {}: {detail}",
+                arguments.join(" "),
+                output.status
             );
         }
         Ok(output)
@@ -117,14 +136,20 @@ mod tests {
 
     const MIB: usize = 1024 * 1024;
 
+    /// These tests write an executable and immediately exec it. A concurrent
+    /// fork in a sibling test can inherit the still-open write descriptor and
+    /// make execve fail with ETXTBSY, so serialise those sections.
+    static EXEC_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
     #[tokio::test(flavor = "current_thread")]
     async fn parses_stats_and_translates_visible_memory_target() -> Result<()> {
+        let _guard = EXEC_LOCK.lock().await;
         let directory = tempfile::tempdir()?;
         let binary = directory.path().join("crosvm");
         let log = directory.path().join("arguments");
         let script = format!(
             r#"#!/bin/sh
-printf '%s\n' "$*" >> '{}'
+printf '%s\n' "$@" >> '{}'
 if [ "$1" = balloon_stats ]; then
     printf '%s\n' '{{"BalloonStats":{{"stats":{{"available_memory":2147483648,"free_memory":1073741824}},"balloon_actual":4294967296}}}}'
 fi
@@ -143,19 +168,26 @@ fi
                 available_memory: 2048 * MIB,
             }
         );
+        assert_eq!(
+            fs::read_to_string(&log)?,
+            "balloon_stats\n/run/crosvm.sock\n"
+        );
+        fs::write(&log, "")?;
+
         endpoint
             .set_visible_memory(4096 * MIB, 12_288 * MIB)
             .await?;
 
         assert_eq!(
             fs::read_to_string(log)?,
-            "balloon_stats /run/crosvm.sock\nballoon 8589934592 /run/crosvm.sock\n"
+            "balloon\n8589934592\n/run/crosvm.sock\n"
         );
         Ok(())
     }
 
     #[tokio::test(flavor = "current_thread")]
     async fn rejects_missing_available_memory() -> Result<()> {
+        let _guard = EXEC_LOCK.lock().await;
         let directory = tempfile::tempdir()?;
         let binary = directory.path().join("crosvm");
         fs::write(
@@ -165,13 +197,30 @@ fi
         fs::set_permissions(&binary, fs::Permissions::from_mode(0o755))?;
 
         let endpoint = CrosvmEndpoint::new(&binary, Path::new("/run/crosvm.sock"));
+        let message = endpoint.query_balloon().await.unwrap_err().to_string();
         assert!(
-            endpoint
-                .query_balloon()
-                .await
-                .unwrap_err()
-                .to_string()
-                .contains("available memory")
+            message.contains("available memory"),
+            "unexpected error: {message}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn reports_crosvm_stdout_on_command_failure() -> Result<()> {
+        let _guard = EXEC_LOCK.lock().await;
+        let directory = tempfile::tempdir()?;
+        let binary = directory.path().join("crosvm");
+        fs::write(
+            &binary,
+            "#!/bin/sh\nprintf '%s\\n' 'unexpected response: connection refused'\nexit 1\n",
+        )?;
+        fs::set_permissions(&binary, fs::Permissions::from_mode(0o755))?;
+
+        let endpoint = CrosvmEndpoint::new(&binary, Path::new("/run/crosvm.sock"));
+        let message = endpoint.query_balloon().await.unwrap_err().to_string();
+        assert!(
+            message.contains("unexpected response: connection refused"),
+            "unexpected error: {message}"
         );
         Ok(())
     }

--- a/packages/rust/ghaf-mem-manager/src/crosvm.rs
+++ b/packages/rust/ghaf-mem-manager/src/crosvm.rs
@@ -1,0 +1,178 @@
+/*
+ * SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+use anyhow::{Context, Result, anyhow, bail};
+use serde::Deserialize;
+use std::{path::PathBuf, process::Output, time::Duration};
+use tokio::{process::Command, time::timeout};
+
+const TIMEOUT: Duration = Duration::from_secs(3);
+
+#[derive(Deserialize, Debug)]
+struct BalloonStatsResponse {
+    #[serde(rename = "BalloonStats")]
+    balloon_stats: BalloonStats,
+}
+
+#[derive(Deserialize, Debug)]
+struct BalloonStats {
+    stats: GuestMemoryStats,
+    balloon_actual: u64,
+}
+
+#[derive(Deserialize, Debug)]
+struct GuestMemoryStats {
+    available_memory: Option<u64>,
+    free_memory: Option<u64>,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct BalloonInfo {
+    pub balloon_actual: usize,
+    pub free_memory: usize,
+    pub available_memory: usize,
+}
+
+#[derive(Hash, PartialEq, Eq, Debug)]
+pub struct CrosvmEndpoint {
+    binary: PathBuf,
+    socket: PathBuf,
+}
+
+impl CrosvmEndpoint {
+    pub fn new(binary: impl Into<PathBuf>, socket: impl Into<PathBuf>) -> Self {
+        Self {
+            binary: binary.into(),
+            socket: socket.into(),
+        }
+    }
+
+    async fn command(&self, arguments: &[&str]) -> Result<Output> {
+        let mut command = Command::new(&self.binary);
+        command.args(arguments).kill_on_drop(true);
+        let output = timeout(TIMEOUT, command.output())
+            .await
+            .context("crosvm control command timed out")??;
+        if !output.status.success() {
+            bail!(
+                "crosvm control command failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        Ok(output)
+    }
+
+    pub async fn query_balloon(&self) -> Result<BalloonInfo> {
+        let socket = self
+            .socket
+            .to_str()
+            .context("crosvm socket path is not valid UTF-8")?;
+        let output = self.command(&["balloon_stats", socket]).await?;
+        let response: BalloonStatsResponse = serde_json::from_slice(&output.stdout)
+            .context("failed to parse crosvm balloon statistics")?;
+        let stats = response.balloon_stats;
+
+        Ok(BalloonInfo {
+            balloon_actual: usize::try_from(stats.balloon_actual)
+                .context("crosvm balloon size does not fit usize")?,
+            free_memory: usize::try_from(stats.stats.free_memory.unwrap_or(0))
+                .context("guest free memory does not fit usize")?,
+            available_memory: usize::try_from(
+                stats
+                    .stats
+                    .available_memory
+                    .ok_or_else(|| anyhow!("guest did not report available memory"))?,
+            )
+            .context("guest available memory does not fit usize")?,
+        })
+    }
+
+    pub async fn set_visible_memory(&self, visible: usize, maximum: usize) -> Result<()> {
+        if visible > maximum {
+            bail!("visible memory target exceeds configured maximum");
+        }
+        let reclaimed = maximum - visible;
+        let reclaimed = reclaimed.to_string();
+        let socket = self
+            .socket
+            .to_str()
+            .context("crosvm socket path is not valid UTF-8")?;
+        self.command(&["balloon", &reclaimed, socket]).await?;
+        Ok(())
+    }
+}
+
+impl std::fmt::Display for CrosvmEndpoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.socket.display().fmt(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, os::unix::fs::PermissionsExt, path::Path};
+
+    use super::*;
+
+    const MIB: usize = 1024 * 1024;
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn parses_stats_and_translates_visible_memory_target() -> Result<()> {
+        let directory = tempfile::tempdir()?;
+        let binary = directory.path().join("crosvm");
+        let log = directory.path().join("arguments");
+        let script = format!(
+            r#"#!/bin/sh
+printf '%s\n' "$*" >> '{}'
+if [ "$1" = balloon_stats ]; then
+    printf '%s\n' '{{"BalloonStats":{{"stats":{{"available_memory":2147483648,"free_memory":1073741824}},"balloon_actual":4294967296}}}}'
+fi
+"#,
+            log.display()
+        );
+        fs::write(&binary, script)?;
+        fs::set_permissions(&binary, fs::Permissions::from_mode(0o755))?;
+
+        let endpoint = CrosvmEndpoint::new(&binary, Path::new("/run/crosvm.sock"));
+        assert_eq!(
+            endpoint.query_balloon().await?,
+            BalloonInfo {
+                balloon_actual: 4096 * MIB,
+                free_memory: 1024 * MIB,
+                available_memory: 2048 * MIB,
+            }
+        );
+        endpoint
+            .set_visible_memory(4096 * MIB, 12_288 * MIB)
+            .await?;
+
+        assert_eq!(
+            fs::read_to_string(log)?,
+            "balloon_stats /run/crosvm.sock\nballoon 8589934592 /run/crosvm.sock\n"
+        );
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn rejects_missing_available_memory() -> Result<()> {
+        let directory = tempfile::tempdir()?;
+        let binary = directory.path().join("crosvm");
+        fs::write(
+            &binary,
+            "#!/bin/sh\nprintf '%s\\n' '{\"BalloonStats\":{\"stats\":{},\"balloon_actual\":0}}'\n",
+        )?;
+        fs::set_permissions(&binary, fs::Permissions::from_mode(0o755))?;
+
+        let endpoint = CrosvmEndpoint::new(&binary, Path::new("/run/crosvm.sock"));
+        assert!(
+            endpoint
+                .query_balloon()
+                .await
+                .unwrap_err()
+                .to_string()
+                .contains("available memory")
+        );
+        Ok(())
+    }
+}

--- a/packages/rust/ghaf-mem-manager/src/main.rs
+++ b/packages/rust/ghaf-mem-manager/src/main.rs
@@ -23,6 +23,27 @@ enum Hypervisor {
     Qemu,
 }
 
+const MAX_CONSECUTIVE_ERRORS: usize = 5;
+
+#[derive(Debug, Default)]
+struct CrosvmEndpointState {
+    last_balloon: Option<Instant>,
+    ready: bool,
+    consecutive_errors: usize,
+}
+
+impl CrosvmEndpointState {
+    fn record_success(&mut self) {
+        self.ready = true;
+        self.consecutive_errors = 0;
+    }
+
+    fn record_error(&mut self) -> bool {
+        self.consecutive_errors += 1;
+        self.ready && self.consecutive_errors >= MAX_CONSECUTIVE_ERRORS
+    }
+}
+
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Args {
@@ -219,25 +240,24 @@ async fn monitor_crosvm(args: &Args) -> Result<()> {
         bail!("--maximum is required for the crosvm backend");
     }
 
-    let mut endpoints: HashMap<_, Option<Instant>> = args
+    let mut endpoints: HashMap<_, CrosvmEndpointState> = args
         .socket
         .iter()
         .map(|path| {
             (
                 CrosvmEndpoint::new(&args.crosvm_binary, path),
-                None::<Instant>,
+                CrosvmEndpointState::default(),
             )
         })
         .collect();
     let dur = Duration::from_secs(args.interval);
     let bival = Duration::from_secs(args.balloon_interval);
     let mut ival = tokio::time::interval(dur);
-    let mut errors = 0;
     ival.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
     loop {
         ival.tick().await;
-        for (endpoint, last_balloon) in &mut endpoints {
+        for (endpoint, state) in &mut endpoints {
             let result = async {
                 let balloon = endpoint.query_balloon().await?;
                 let visible_memory = args.maximum.saturating_sub(balloon.balloon_actual);
@@ -259,27 +279,37 @@ async fn monitor_crosvm(args: &Args) -> Result<()> {
                     .window(args.low, args.high)
                     .map(|t| t.clamp(args.minimum, args.maximum))
                     .filter(|&t| t != stats.balloon_size)
-                    .filter(|_| last_balloon.is_none_or(|last| last.elapsed() >= bival))
+                    .filter(|_| {
+                        state
+                            .last_balloon
+                            .is_none_or(|last| last.elapsed() >= bival)
+                    })
                 {
                     info!(
                         "Adjusting {endpoint} visible memory from {} to {target}",
                         stats.balloon_size
                     );
                     endpoint.set_visible_memory(target, args.maximum).await?;
-                    last_balloon.replace(Instant::now());
+                    state.last_balloon.replace(Instant::now());
                 }
                 Result::Ok(())
             }
             .await;
 
             if let Err(error) = result {
-                errors += 1;
-                if errors >= 5 {
+                if state.record_error() {
                     return Err(error);
                 }
-                warn!("Got error {error} with {endpoint} for the {errors}th time");
+                if state.ready {
+                    warn!(
+                        "Got error {error} with {endpoint} for the {}th time",
+                        state.consecutive_errors
+                    );
+                } else {
+                    warn!("Crosvm endpoint {endpoint} is not ready: {error}; trying again");
+                }
             } else {
-                errors = 0;
+                state.record_success();
             }
         }
     }
@@ -305,7 +335,22 @@ async fn main() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use super::MemoryStats;
+    use super::{CrosvmEndpointState, MAX_CONSECUTIVE_ERRORS, MemoryStats};
+
+    #[test]
+    fn crosvm_startup_errors_do_not_exhaust_runtime_budget() {
+        let mut state = CrosvmEndpointState::default();
+
+        for _ in 0..(MAX_CONSECUTIVE_ERRORS * 2) {
+            assert!(!state.record_error());
+        }
+
+        state.record_success();
+        for _ in 1..MAX_CONSECUTIVE_ERRORS {
+            assert!(!state.record_error());
+        }
+        assert!(state.record_error());
+    }
 
     fn stats(balloon_size: usize, available_memory: usize) -> MemoryStats {
         MemoryStats {

--- a/packages/rust/ghaf-mem-manager/src/main.rs
+++ b/packages/rust/ghaf-mem-manager/src/main.rs
@@ -2,8 +2,8 @@
  * SPDX-FileCopyrightText: 2022-2026 TII (SSRC) and the Ghaf contributors
  * SPDX-License-Identifier: Apache-2.0
  */
-use anyhow::Result;
-use clap::Parser;
+use anyhow::{Result, bail};
+use clap::{Parser, ValueEnum};
 use std::{
     collections::HashMap,
     path::PathBuf,
@@ -11,15 +11,32 @@ use std::{
 };
 use tracing::{debug, info, warn};
 
+mod crosvm;
 mod qmp;
+use crosvm::CrosvmEndpoint;
 use qmp::QmpEndpoint;
+
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+enum Hypervisor {
+    Crosvm,
+    #[default]
+    Qemu,
+}
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// Path to QMP socket
+    /// Path to the VM control socket
     #[arg(short, long)]
     socket: Vec<PathBuf>,
+
+    /// Hypervisor control protocol
+    #[arg(long, value_enum, default_value_t)]
+    hypervisor: Hypervisor,
+
+    /// Path to the crosvm executable
+    #[arg(long, default_value = "crosvm")]
+    crosvm_binary: PathBuf,
 
     /// Monitoring interval in seconds
     #[arg(short, long, default_value_t = 1)]
@@ -121,7 +138,7 @@ impl std::fmt::Display for MemoryStats {
     }
 }
 
-async fn monitor_memory(args: Args) -> Result<()> {
+async fn monitor_qemu(args: &Args) -> Result<()> {
     let mut qmps: HashMap<_, (_, Option<Instant>)> = args
         .socket
         .iter()
@@ -194,6 +211,88 @@ async fn monitor_memory(args: Args) -> Result<()> {
                 errors = 0;
             }
         }
+    }
+}
+
+async fn monitor_crosvm(args: &Args) -> Result<()> {
+    if args.maximum == usize::MAX {
+        bail!("--maximum is required for the crosvm backend");
+    }
+
+    let mut endpoints: HashMap<_, Option<Instant>> = args
+        .socket
+        .iter()
+        .map(|path| {
+            (
+                CrosvmEndpoint::new(&args.crosvm_binary, path),
+                None::<Instant>,
+            )
+        })
+        .collect();
+    let dur = Duration::from_secs(args.interval);
+    let bival = Duration::from_secs(args.balloon_interval);
+    let mut ival = tokio::time::interval(dur);
+    let mut errors = 0;
+    ival.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        ival.tick().await;
+        for (endpoint, last_balloon) in &mut endpoints {
+            let result = async {
+                let balloon = endpoint.query_balloon().await?;
+                let visible_memory = args.maximum.saturating_sub(balloon.balloon_actual);
+                let stats = MemoryStats {
+                    balloon_size: visible_memory,
+                    base_memory: args.maximum,
+                    plugged_memory: 0,
+                    total_memory: args.maximum,
+                    free_memory: balloon.free_memory,
+                    available_memory: balloon.available_memory,
+                };
+
+                debug!(
+                    "Stats for {endpoint}: {stats}, pressure: {}%, reclaimed: {} MiB",
+                    stats.pressure(),
+                    balloon.balloon_actual / 1024 / 1024
+                );
+                if let Some(target) = stats
+                    .window(args.low, args.high)
+                    .map(|t| t.clamp(args.minimum, args.maximum))
+                    .filter(|&t| t != stats.balloon_size)
+                    .filter(|_| last_balloon.is_none_or(|last| last.elapsed() >= bival))
+                {
+                    info!(
+                        "Adjusting {endpoint} visible memory from {} to {target}",
+                        stats.balloon_size
+                    );
+                    endpoint.set_visible_memory(target, args.maximum).await?;
+                    last_balloon.replace(Instant::now());
+                }
+                Result::Ok(())
+            }
+            .await;
+
+            if let Err(error) = result {
+                errors += 1;
+                if errors >= 5 {
+                    return Err(error);
+                }
+                warn!("Got error {error} with {endpoint} for the {errors}th time");
+            } else {
+                errors = 0;
+            }
+        }
+    }
+}
+
+async fn monitor_memory(args: Args) -> Result<()> {
+    if args.minimum > args.maximum {
+        bail!("--minimum cannot exceed --maximum");
+    }
+
+    match args.hypervisor {
+        Hypervisor::Crosvm => monitor_crosvm(&args).await,
+        Hypervisor::Qemu => monitor_qemu(&args).await,
     }
 }
 

--- a/packages/rust/ghaf-mem-manager/src/main.rs
+++ b/packages/rust/ghaf-mem-manager/src/main.rs
@@ -9,7 +9,7 @@ use std::{
     path::PathBuf,
     time::{Duration, Instant},
 };
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, warn};
 
 mod crosvm;
 mod qmp;
@@ -38,9 +38,16 @@ impl CrosvmEndpointState {
         self.consecutive_errors = 0;
     }
 
+    /// Returns true when a ready endpoint exhausts its error budget. The
+    /// endpoint then returns to the startup grace period so a restarted VM can
+    /// recover without restarting the manager.
     fn record_error(&mut self) -> bool {
         self.consecutive_errors += 1;
-        self.ready && self.consecutive_errors >= MAX_CONSECUTIVE_ERRORS
+        let exhausted = self.ready && self.consecutive_errors >= MAX_CONSECUTIVE_ERRORS;
+        if exhausted {
+            self.ready = false;
+        }
+        exhausted
     }
 }
 
@@ -177,7 +184,7 @@ async fn monitor_qemu(args: &Args) -> Result<()> {
             let (conn, task, mut receiver) = match qmp.connect().await {
                 Ok(ctr) => ctr,
                 Err(e) => {
-                    warn!("Connection to {qmp} failed: {e}, trying again later",);
+                    warn!("Connection to {qmp} failed: {e:#}, trying again later",);
                     continue;
                 }
             };
@@ -223,10 +230,10 @@ async fn monitor_qemu(args: &Args) -> Result<()> {
                 } => Ok(()),
             } {
                 errors += 1;
-                if errors >= 5 {
+                if errors >= MAX_CONSECUTIVE_ERRORS {
                     Err(e)?;
                 } else {
-                    warn!("Got error {e} with {qmp} for the {errors}th time");
+                    warn!("Got error {e:#} with {qmp} for the {errors}th time");
                 }
             } else {
                 errors = 0;
@@ -238,6 +245,9 @@ async fn monitor_qemu(args: &Args) -> Result<()> {
 async fn monitor_crosvm(args: &Args) -> Result<()> {
     if args.maximum == usize::MAX {
         bail!("--maximum is required for the crosvm backend");
+    }
+    if args.maximum == 0 {
+        bail!("--maximum must be greater than zero");
     }
 
     let mut endpoints: HashMap<_, CrosvmEndpointState> = args
@@ -260,7 +270,17 @@ async fn monitor_crosvm(args: &Args) -> Result<()> {
         for (endpoint, state) in &mut endpoints {
             let result = async {
                 let balloon = endpoint.query_balloon().await?;
-                let visible_memory = args.maximum.saturating_sub(balloon.balloon_actual);
+                if !state.ready {
+                    state.record_success();
+                }
+                let Some(visible_memory) = args.maximum.checked_sub(balloon.balloon_actual) else {
+                    bail!(
+                        "crosvm reports {} B reclaimed on {endpoint}, above --maximum {} B; \
+                         --maximum must match the VM's configured memory size",
+                        balloon.balloon_actual,
+                        args.maximum
+                    );
+                };
                 let stats = MemoryStats {
                     balloon_size: visible_memory,
                     base_memory: args.maximum,
@@ -298,15 +318,18 @@ async fn monitor_crosvm(args: &Args) -> Result<()> {
 
             if let Err(error) = result {
                 if state.record_error() {
-                    return Err(error);
-                }
-                if state.ready {
+                    error!(
+                        "Crosvm endpoint {endpoint} failed {} consecutive times: {error:#}; \
+                         waiting for it to become reachable again",
+                        state.consecutive_errors
+                    );
+                } else if state.ready {
                     warn!(
-                        "Got error {error} with {endpoint} for the {}th time",
+                        "Got error {error:#} with {endpoint} for the {}th time",
                         state.consecutive_errors
                     );
                 } else {
-                    warn!("Crosvm endpoint {endpoint} is not ready: {error}; trying again");
+                    warn!("Crosvm endpoint {endpoint} is not ready: {error:#}; trying again");
                 }
             } else {
                 state.record_success();
@@ -316,6 +339,9 @@ async fn monitor_crosvm(args: &Args) -> Result<()> {
 }
 
 async fn monitor_memory(args: Args) -> Result<()> {
+    if args.socket.is_empty() {
+        bail!("at least one --socket is required");
+    }
     if args.minimum > args.maximum {
         bail!("--minimum cannot exceed --maximum");
     }
@@ -350,6 +376,15 @@ mod tests {
             assert!(!state.record_error());
         }
         assert!(state.record_error());
+        assert!(!state.ready);
+
+        for _ in 0..MAX_CONSECUTIVE_ERRORS {
+            assert!(!state.record_error());
+        }
+
+        state.record_success();
+        assert!(state.ready);
+        assert_eq!(state.consecutive_errors, 0);
     }
 
     fn stats(balloon_size: usize, available_memory: usize) -> MemoryStats {

--- a/packages/rust/ghaf-mem-manager/src/qmp.rs
+++ b/packages/rust/ghaf-mem-manager/src/qmp.rs
@@ -221,7 +221,7 @@ impl QmpConnection {
             rx.recv()
                 .await
                 .context("Invalid response")?
-                .map_err(|e| anyhow!("{}", e.to_string()))?,
+                .map_err(|e| anyhow!("{e}"))?,
         )?)
     }
 


### PR DESCRIPTION
## Description

Add an explicit Crosvm backend to `ghaf-mem-manager` while preserving QEMU/QMP as the default. This unblocks dynamic memory management for Ghaf AppVMs that run with Crosvm.

Crosvm reports ballooned bytes and its `balloon` command accepts bytes to reclaim. The existing manager works in guest-visible memory targets, so this backend translates with `reclaimed = maximum - visible`.

The Crosvm control socket is created after the VM service starts. The manager now retries each endpoint until its first successful query instead of exhausting its runtime failure budget during this normal startup window. After readiness, five consecutive errors are escalated and the endpoint returns to startup grace so it can recover from a VM restart. Readiness and errors are tracked independently per endpoint.

The Crosvm control socket uses an internal serialized protocol, so the backend invokes the packaged Crosvm control commands rather than duplicating that private protocol.

Related to https://github.com/tiiuae/ghaf/pull/2123

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [x] Documentation update
- [x] Nix configuration change

## Changes Made

- Add `--hypervisor crosvm` and `--crosvm-binary` options.
- Query `crosvm balloon_stats` and adjust memory with `crosvm balloon`.
- Require `--maximum` and translate visible-memory targets to reclaimed bytes.
- Retry startup connection failures until each Crosvm endpoint becomes ready.
- Escalate five consecutive post-readiness errors, then retry until the endpoint recovers.
- Reject an empty `--socket` for both backends. A QEMU invocation that previously ran as a silent no-op now fails at startup; Ghaf always passes a socket.
- Cover JSON parsing, command translation, missing statistics, arithmetic boundaries, and startup readiness with unit tests.
- Document QEMU and Crosvm invocation.

## Testing Done

- `cargo clippy --all-targets -- -D warnings`
- `cargo test`: 16 passed
- `nix build .#ghaf-mem-manager`: release build and 16 release tests passed on `artemis2`
- `nix fmt -- --fail-on-change`
- `nix develop --command reuse lint`
- Ghaf `intel-laptop-debug-installer` build with the updated package

Live x86 testing of the previous revision reproduced all five AppVM memory-manager services losing the Crosvm socket startup race while later direct `balloon_stats` commands succeeded. The corrected installer has been built but not yet deployed, so post-fix live validation remains pending.

## Package Impact

Affected package: `ghaf-mem-manager`.

## Checklist

- [x] Code follows project style guidelines
- [x] SPDX license headers remain valid
- [x] Documentation updated
- [x] No trailing whitespace
- [x] Commit messages follow the contribution guidelines
- [x] QEMU balloon behavior remains unchanged
- [x] Security implications considered
- [x] Nix best practices followed

