### PR TITLE
fix: suppress Crosvm control log noise

### DIFF
--- a/packages/rust/ghaf-mem-manager/src/crosvm.rs
+++ b/packages/rust/ghaf-mem-manager/src/crosvm.rs
@@ -50,7 +50,10 @@ impl CrosvmEndpoint {
 
     async fn command(&self, arguments: &[&str]) -> Result<Output> {
         let mut command = Command::new(&self.binary);
-        command.args(arguments).kill_on_drop(true);
+        command
+            .arg("--no-syslog")
+            .args(arguments)
+            .kill_on_drop(true);
         let output = timeout(TIMEOUT, command.output())
             .await
             .with_context(|| {
@@ -150,7 +153,7 @@ mod tests {
         let script = format!(
             r#"#!/bin/sh
 printf '%s\n' "$@" >> '{}'
-if [ "$1" = balloon_stats ]; then
+if [ "$2" = balloon_stats ]; then
     printf '%s\n' '{{"BalloonStats":{{"stats":{{"available_memory":2147483648,"free_memory":1073741824}},"balloon_actual":4294967296}}}}'
 fi
 "#,
@@ -170,7 +173,7 @@ fi
         );
         assert_eq!(
             fs::read_to_string(&log)?,
-            "balloon_stats\n/run/crosvm.sock\n"
+            "--no-syslog\nballoon_stats\n/run/crosvm.sock\n"
         );
         fs::write(&log, "")?;
 
@@ -180,7 +183,7 @@ fi
 
         assert_eq!(
             fs::read_to_string(log)?,
-            "balloon\n8589934592\n/run/crosvm.sock\n"
+            "--no-syslog\nballoon\n8589934592\n/run/crosvm.sock\n"
         );
         Ok(())
     }


### PR DESCRIPTION
## Description

Invoke Crosvm control commands with `--no-syslog` in `ghaf-mem-manager` to suppress routine control traffic from info-level logs. The functional control path is unchanged.

The original branch also moved USB notification and device-inventory payloads to debug logging. Those changes are now present in `main` via `ea930a3`, so their two commits were dropped during the rebase as already upstream.

## Validation

- rebased onto current `main` (`2dcc258`);
- range-diff confirms the mem-manager patch is unchanged (`6c061dd` -> `87919d2`);
- `git diff --check` passes;
- all 16 `ghaf-mem-manager` unit tests pass;
- `nix fmt -- --fail-on-change` passes;
- `nix flake show` passes;
- `nix flake check` passes for the native `x86_64-linux` checks (the command reports `aarch64-linux` as incompatible and omitted);
- `reuse lint` passes;
- pre-push `end-of-file-fixer`, `reuse`, and `treefmt` hooks pass.

Ghaf PR tiiuae/ghaf#2133 carries this as a temporary package patch until this PR merges.
